### PR TITLE
fix(cli): tighten constraints on the various Path parameters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,9 @@ jobs:
 
       - name: Install Linux system dependencies
         if: runner.os == 'Linux' && matrix.install-ffmpeg
-        run: sudo apt-get -y install ffmpeg
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install ffmpeg
 
       - name: Install macOS system dependencies
         if: runner.os == 'macOS' && matrix.install-ffmpeg

--- a/lektor/cli.py
+++ b/lektor/cli.py
@@ -24,7 +24,9 @@ version = metadata.version("Lektor")
 
 @click.group(cls=AliasedGroup)
 @click.option(
-    "--project", type=click.Path(), help="The path to the lektor project to work with."
+    "--project",
+    type=click.Path(exists=True),
+    help="The path to the lektor project to work with.",
 )
 @click.option(
     "--language",
@@ -51,7 +53,7 @@ def cli(ctx, project=None, language=None):
 @click.option(
     "-O",
     "--output-path",
-    type=ResolvedPath(),
+    type=ResolvedPath(writable=True, file_okay=False),
     default=None,
     help="The output path.",
 )
@@ -80,7 +82,7 @@ def cli(ctx, project=None, language=None):
 )
 @click.option(
     "--buildstate-path",
-    type=click.Path(),
+    type=click.Path(writable=True, file_okay=False),
     default=None,
     help="Path to a directory that Lektor will use for coordinating "
     "the state of the build. Defaults to a directory named "
@@ -166,7 +168,7 @@ def build_cmd(
 @click.option(
     "-O",
     "--output-path",
-    type=ResolvedPath(),
+    type=ResolvedPath(writable=True, file_okay=False),
     default=None,
     help="The output path.",
 )
@@ -206,7 +208,7 @@ def clean_cmd(ctx, output_path, verbosity, extra_flags):
 @click.option(
     "-O",
     "--output-path",
-    type=ResolvedPath(),
+    type=ResolvedPath(writable=True, file_okay=False),
     default=None,
     help="The output path.",
 )
@@ -313,7 +315,7 @@ def deploy_cmd(ctx, server, output_path, extra_flags, **credentials):
 @click.option(
     "-O",
     "--output-path",
-    type=ResolvedPath(),
+    type=ResolvedPath(writable=True, file_okay=False),
     default=None,
     help="The dev server will build into the same folder as "
     "the build command by default.",
@@ -426,7 +428,7 @@ def project_info_cmd(ctx, as_json, **opts):
     "content-file-info", short_help="Provides information for " "a set of lektor files."
 )
 @click.option("as_json", "--json", is_flag=True, help="Prints out the data as json.")
-@click.argument("files", nargs=-1, type=click.Path())
+@click.argument("files", nargs=-1, type=click.Path(dir_okay=False))
 @pass_context
 def content_file_info_cmd(ctx, files, as_json):
     """Given a list of files this returns the information for those files
@@ -617,7 +619,11 @@ def plugins_reinstall_cmd(ctx):
 
 @cli.command("quickstart", short_help="Starts a new empty project.")
 @click.option("--name", help="The name of the project.")
-@click.option("--path", type=click.Path(), help="Output directory")
+@click.option(
+    "--path",
+    type=click.Path(file_okay=False, dir_okay=False, writable=True),
+    help="Output directory",
+)
 @pass_context
 def quickstart_cmd(ctx, **options):
     """Starts a new empty project with a minimum boilerplate."""

--- a/lektor/cli.py
+++ b/lektor/cli.py
@@ -11,6 +11,7 @@ from lektor.cli_utils import echo_json
 from lektor.cli_utils import extraflag
 from lektor.cli_utils import pass_context
 from lektor.cli_utils import pruneflag
+from lektor.cli_utils import ResolvedPath
 from lektor.cli_utils import validate_language
 from lektor.compat import importlib_metadata as metadata
 from lektor.project import Project
@@ -48,7 +49,11 @@ def cli(ctx, project=None, language=None):
 
 @cli.command("build")
 @click.option(
-    "-O", "--output-path", type=click.Path(), default=None, help="The output path."
+    "-O",
+    "--output-path",
+    type=ResolvedPath(),
+    default=None,
+    help="The output path.",
 )
 @click.option(
     "--watch",
@@ -159,7 +164,11 @@ def build_cmd(
 
 @cli.command("clean")
 @click.option(
-    "-O", "--output-path", type=click.Path(), default=None, help="The output path."
+    "-O",
+    "--output-path",
+    type=ResolvedPath(),
+    default=None,
+    help="The output path.",
 )
 @click.option(
     "-v",
@@ -195,7 +204,11 @@ def clean_cmd(ctx, output_path, verbosity, extra_flags):
 @cli.command("deploy", short_help="Deploy the website.")
 @click.argument("server", required=False)
 @click.option(
-    "-O", "--output-path", type=click.Path(), default=None, help="The output path."
+    "-O",
+    "--output-path",
+    type=ResolvedPath(),
+    default=None,
+    help="The output path.",
 )
 @click.option(
     "--username",
@@ -300,7 +313,7 @@ def deploy_cmd(ctx, server, output_path, extra_flags, **credentials):
 @click.option(
     "-O",
     "--output-path",
-    type=click.Path(),
+    type=ResolvedPath(),
     default=None,
     help="The dev server will build into the same folder as "
     "the build command by default.",

--- a/lektor/environment/__init__.py
+++ b/lektor/environment/__init__.py
@@ -4,8 +4,8 @@ import uuid
 from functools import update_wrapper
 from typing import TYPE_CHECKING
 
+import babel.dates
 import jinja2
-from babel import dates
 from jinja2.loaders import split_template_path
 
 from lektor.constants import PRIMARY_ALT
@@ -34,27 +34,93 @@ if TYPE_CHECKING:
     from typing import Literal
 
 
-def _pass_locale(func):
-    def new_func(*args, **kwargs):
-        if kwargs.get("locale", None) is None:
+def _prevent_inlining(wrapped):
+    """Ensure wrapped jinja filter does not get inlined by the template compiler.
+
+    The jinja compiler normally assumes that filters are pure functions (whose
+    result depends only on their parameters) and will inline filter calls that
+    are applied to compile-time constants.
+
+    E.g.
+
+        'say {{ "foo" | upper }}'
+
+    will be compiled to
+
+        "say Foo"
+
+    Many of our filters depend on global state (e..g the Lektor build context).
+
+    Applying this decorator to them will ensure they are not inlined.
+    """
+    # the use of @pass_context will prevent inlining
+    @jinja2.pass_context
+    def wrapper(_jinja_ctx, *args, **kwargs):
+        return wrapped(*args, **kwargs)
+
+    return update_wrapper(wrapper, wrapped)
+
+
+def _dates_filter(name, wrapped):
+    """Wrap one of the babel.dates.format_* functions for use as a jinja filter.
+
+    This will create a jinja filter that will:
+
+    - Check for *undefined* date/time input (and, in that case, return an empty string).
+
+    - Check that the ``format`` and ``locale`` parameters, if provided, have the correct
+      types, otherwise raising ``TypeError``.
+
+    - Raise ``TypeError`` with a somewhat informative message if the wrapped formatting
+      function raises an unexpected exception.  Such an exception is most likely due to
+      being passed an unsupported date/time time.  (The Babel formatting functions
+      accept a fairly wide range of input types — and that range might potentially vary
+      between releases — so we do not explicitly check the input type before passing it
+      on to Babel.)
+
+    If `locale` is not specified, we fill it in based on the current *alt*.
+
+    """
+
+    @_prevent_inlining
+    def wrapper(arg, format="medium", **kwargs):
+        if isinstance(arg, jinja2.Undefined):
+            # This will typically return an empty string, though it depends on the
+            # specific type of undefined instance.  E.g. if arg is a DebugUndefined, it
+            # will return a more descriptive message, and if arg is a StrictUndefined,
+            # an UndefinedError will be raised.
+            return str(arg)
+
+        if not isinstance(format, str):
+            raise TypeError(
+                f"The 'format' parameter to '{name}' should be a str, not {format!r}"
+            )
+
+        locale = kwargs.get("locale")
+        if locale is None:
             kwargs["locale"] = get_locale("en_US")
-        return func(*args, **kwargs)
 
-    return update_wrapper(new_func, func)
+        try:
+            return wrapped(arg, format, **kwargs)
+        except (TypeError, ValueError):
+            raise
+        except Exception as exc:
+            raise TypeError(
+                f"While evaluating filter '{name}', an unexpected exception was raised. "
+                "This is likely caused by an input or parameter of an unsupported type."
+            ) from exc
+
+    return update_wrapper(wrapper, wrapped)
 
 
-@jinja2.pass_context
+@_prevent_inlining
 def _markdown_filter(
-    _jinja_context: jinja2.runtime.Context,
     source: str,
     *,
     resolve_links: "Literal['always', 'never', 'when-possible', None]" = None,
-    **kw: str
+    **kw: str,
 ) -> Markdown:
     """A jinja filter that converts markdown text to HTML."""
-    # By default Jinja treats filters as pure functions, and will memoize
-    # their results. Since here we depend on global context, we mark the filter
-    # as a "context filter" to prevent memoization.
     ctx = get_ctx()
     source_obj = ctx.source if ctx is not None else None
     return Markdown(
@@ -154,11 +220,8 @@ class Environment:
             latformat=lambda x, secs=True: format_lat_long(lat=x, secs=secs),
             longformat=lambda x, secs=True: format_lat_long(long=x, secs=secs),
             latlongformat=lambda x, secs=True: format_lat_long(secs=secs, *x),
-            # By default filters need to be side-effect free.  This is not
-            # the case for this one, so we need to make it as a dummy
-            # context filter so that jinja2 will not inline it.
-            url=jinja2.pass_context(lambda ctx, *a, **kw: url_to(*a, **kw)),
-            asseturl=jinja2.pass_context(lambda ctx, *a, **kw: get_asset_url(*a, **kw)),
+            url=_prevent_inlining(url_to),
+            asseturl=_prevent_inlining(get_asset_url),
             markdown=_markdown_filter,
         )
         self.jinja_env.globals.update(
@@ -171,9 +234,9 @@ class Environment:
             get_random_id=lambda: uuid.uuid4().hex,
         )
         self.jinja_env.filters.update(
-            datetimeformat=_pass_locale(dates.format_datetime),
-            dateformat=_pass_locale(dates.format_date),
-            timeformat=_pass_locale(dates.format_time),
+            dateformat=_dates_filter("dateformat", babel.dates.format_date),
+            datetimeformat=_dates_filter("datetimeformat", babel.dates.format_datetime),
+            timeformat=_dates_filter("timeformat", babel.dates.format_time),
         )
 
         # pylint: disable=import-outside-toplevel

--- a/lektor/project.py
+++ b/lektor/project.py
@@ -108,12 +108,13 @@ class Project:
 
     def get_output_path(self):
         """The path where output files are stored."""
-        config = self.open_config()
+        config = self.open_config()  # raises if no project_file
         output_path = config.get("project.output_path")
         if output_path:
-            return os.path.join(self.tree, os.path.normpath(output_path))
-
-        return os.path.join(get_cache_dir(), "builds", self.id)
+            path = Path(config.filename).parent / output_path
+        else:
+            path = Path(get_cache_dir(), "builds", self.id)
+        return str(path)
 
     class PackageCacheType(Enum):
         VENV = "venv"  # The new virtual environment-based package cache

--- a/tests/demo-project/Website.lektorproject
+++ b/tests/demo-project/Website.lektorproject
@@ -7,11 +7,13 @@ included_assets = _*
 name = English
 name[de] = Englisch
 primary = yes
+locale = en_US
 
 [alternatives.de]
 name = German
 name[de] = Deutsch
 url_prefix = /de/
+locale = de_DE
 
 [servers.production]
 enabled = yes

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -1,0 +1,21 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from lektor.cli_utils import ResolvedPath
+
+
+@pytest.mark.parametrize("file_exists", [True, False])
+def test_ResolvedPath_resolves_relative_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, file_exists: bool
+) -> None:
+    resolved_path = ResolvedPath()
+    monkeypatch.chdir(tmp_path)
+    if file_exists:
+        Path(tmp_path, "filename").touch()
+
+    resolved = resolved_path.convert("filename", None, None)
+    assert isinstance(resolved, str)
+    # NB: os.path.realpath does not resolve symlinks on Windows with Python==3.7
+    assert resolved == os.path.join(Path().resolve(), "filename")

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,3 +1,4 @@
+import datetime
 import re
 import sys
 from html import unescape
@@ -6,6 +7,7 @@ from pathlib import Path
 import pytest
 
 import lektor.context
+from lektor.environment import Environment
 
 
 @pytest.fixture
@@ -110,3 +112,76 @@ def test_no_reference_cycle_in_environment(project):
     # reference count should be two: one from our `env` variable, and
     # another from the argument to sys.getrefcount
     assert sys.getrefcount(env) == 2
+
+
+@pytest.fixture
+def render_string(env):
+    def render_string(s, **kwargs):
+        template = env.jinja_env.from_string(s)
+        return template.render(**kwargs)
+
+    return render_string
+
+
+def test_dateformat_filter(render_string):
+    tmpl = "{{ dt | dateformat('yyyy-MM-dd') }}"
+    dt = datetime.date(2001, 2, 3)
+    assert render_string(tmpl, dt=dt) == "2001-02-03"
+
+
+def test_datetimeformat_filter_not_inlined(pad):
+    template = pad.env.jinja_env.from_string("{{ 1678749806 | datetimeformat }}")
+    en_date = template.render()
+    with lektor.context.Context(pad=pad) as ctx:
+        ctx.source = pad.get("/", alt="de")
+        de_date = template.render()
+    assert en_date != de_date
+
+
+def test_datetimeformat_filter(render_string):
+    tmpl = "{{ dt | datetimeformat('yyyy-MM-ddTHH:mm') }}"
+    dt = datetime.datetime(2001, 2, 3, 4, 5, 6)
+    assert render_string(tmpl, dt=dt) == "2001-02-03T04:05"
+
+
+def test_timeformat_filter(render_string):
+    tmpl = "{{ dt | datetimeformat('HH:mm') }}"
+    dt = datetime.time(1, 2, 3)
+    assert render_string(tmpl, dt=dt) == "01:02"
+
+
+@pytest.fixture(params=["dateformat", "datetimeformat", "timeformat"])
+def dates_filter(request: pytest.FixtureRequest) -> str:
+    return request.param
+
+
+def test_dates_format_filter_handles_undefined(
+    env: Environment, dates_filter: str
+) -> None:
+    template = env.jinja_env.from_string("{{ undefined | %s }}" % dates_filter)
+    assert template.render() == ""
+
+
+def test_dates_format_filter_raises_type_error_on_bad_arg(
+    env: Environment, dates_filter: str
+) -> None:
+    template = env.jinja_env.from_string("{{ obj | %s }}" % dates_filter)
+    with pytest.raises(TypeError, match="unexpected exception"):
+        template.render(obj=object())
+
+
+def test_dates_format_filter_raises_type_error_on_bad_format(
+    env: Environment, dates_filter: str
+) -> None:
+    template = env.jinja_env.from_string("{{ now | %s(42) }}" % dates_filter)
+    with pytest.raises(TypeError, match="should be a str"):
+        template.render(now=datetime.datetime.now())
+
+
+@pytest.mark.parametrize("arg", ["locale", "tzinfo"])
+def test_dates_format_filter_raises_type_error_on_bad_kwarg(
+    env: Environment, dates_filter: str, arg: str
+) -> None:
+    template = env.jinja_env.from_string("{{ now | %s(%s=42) }}" % (dates_filter, arg))
+    with pytest.raises(TypeError):
+        template.render(now=datetime.datetime.now())

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,0 +1,28 @@
+import inspect
+from pathlib import Path
+
+from lektor.project import Project
+
+
+def test_Project_get_output_path(tmp_path: Path) -> None:
+    project_file = tmp_path / "test.lektorproject"
+    project_file.touch()
+    project = Project.from_file(project_file)
+    assert Path(project.get_output_path()).parts[-2:] == ("builds", project.id)
+
+
+def test_Project_get_output_path_is_relative_to_project_file(tmp_path: Path) -> None:
+    tree = tmp_path / "tree"
+    tree.mkdir()
+    project_file = tmp_path / "test.lektorproject"
+    project_file.write_text(
+        inspect.cleandoc(
+            """[project]
+            path = tree
+            output_path = htdocs
+            """
+        )
+    )
+
+    project = Project.from_file(project_file)
+    assert project.get_output_path() == str(tmp_path / "htdocs")


### PR DESCRIPTION
This results in better error messages when, e.g., the user specifies a file when a directory is expected.

<!---
Remember to please check that your code passes tests locally. Test with the Makefile
commands `make test`, or if you only need to test just Python / JS `make test-python`
or `make test-js`.
--->

### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->


### Related Issues / Links

This is stacked (depends) on #1120
<!---
Are there any similar or related issues or pull requests?
Did you make a pull request to update the docs?
--->

### Description of Changes

- [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->

<!--- Explain what you've done and why --->

<!--- Thanks for your help making Lektor better for everyone! --->
